### PR TITLE
Mlafi Stays Dead _ Arrows Fixed

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 554075238}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.61, y: 0.49, z: 0}
+  m_LocalPosition: {x: 0, y: 0.49, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4248948148176905316}
@@ -255,6 +255,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   firePoint: {fileID: 554075239}
   projectile: {fileID: 1457549573367568210, guid: 3af590a6e30a72c40af9ee35e1b765f9, type: 3}
+  canShoot: 0
+  arrowCooldown: 0
 --- !u!114 &97503018
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlayerProjectile.prefab
+++ b/Assets/Prefabs/PlayerProjectile.prefab
@@ -121,7 +121,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.38
 --- !u!114 &9016857787908278595
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerTest.cs
+++ b/Assets/Scripts/PlayerTest.cs
@@ -25,6 +25,8 @@ public class PlayerTest : MonoBehaviour
     void Update()
     {
 
+        if (GetComponent<move>().Mode == "Dead") { return; }
+
         if (Input.GetButtonDown("Fire2") && canShoot)
         {
             Shoot();


### PR DESCRIPTION
Mlafi won't revive himself if the player presses buttons while dead.
-Stopped PlayerTest from running if Mlafi's Dead
-May need to merge player test more effectively into the Player Control Script


Arrows won't immediately die if you are next to a wall.
- Arrow hitbox reduced to prevent wall collision
- Arrow instantiates from center now
